### PR TITLE
イベント編集画面での表示修正

### DIFF
--- a/app/javascript/packs/common.js
+++ b/app/javascript/packs/common.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', window.viewChange = function viewChange() {
+document.addEventListener('turbolinks:load', window.viewChange = function viewChange() {
   mode = document.getElementById("event_mode").value;
   pn = document.getElementById("people_number");
   if ( mode == 'equal' ) {


### PR DESCRIPTION
## 概要
単位モードでイベント詳細から編集に遷移した際、支払い人数が表示されていたため修正。